### PR TITLE
Use the first bash found in $PATH for script

### DIFF
--- a/hack/webhook-patch-ca-bundle.sh
+++ b/hack/webhook-patch-ca-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Original script found at: https://github.com/morvencao/kube-mutating-webhook-tutorial/blob/master/deployment/webhook-patch-ca-bundle.sh
 
 ROOT=$(cd $(dirname $0)/../../; pwd)


### PR DESCRIPTION
/bin/bash doesn't exist on all systems (NixOS specifically) whereas /usr/bin/env bash should exist on all compatible platforms (Mac w/ homebrew, all Linux dists, haven't tested BSD's)

*Issue #, if available:*

*Description of changes:*
Use available bash rather than hardcoded one

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
